### PR TITLE
fix: Sort demand buses in scenario generation and on run startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = "==3.12.*"
 dependencies = [
     "gurobipy>=13.0.0",
     "matplotlib>=3.10.8",
+    "natsort>=8.4.0",
     "numpy>=2.4.0",
     "pandas>=2.3.3",
     "scipy>=1.16.3",

--- a/sddip/sddip/parameters.py
+++ b/sddip/sddip/parameters.py
@@ -239,23 +239,28 @@ class Parameters:
         p_d = []
         re = []
 
+        sorted_columns = scenario_df.columns.sort_values()
         for t in range(self.n_stages):
-            stage_df = scenario_df[scenario_df["t"] == t + 1]
+            stage_df = pd.DataFrame(scenario_df[scenario_df["t"] == t + 1])
             p_d.append(
                 stage_df[
-                    scenario_df.columns[
-                        scenario_df.columns.to_series().str.contains("Pd")
+                    sorted_columns[
+                        sorted_columns.to_series().str.contains("Pd")
                     ]
-                ].values.tolist()
+                ]
+                .to_numpy()
+                .tolist()
             )
             re.append(
                 stage_df[
-                    scenario_df.columns[
-                        scenario_df.columns.to_series().str.contains("Re")
+                    sorted_columns[
+                        sorted_columns.to_series().str.contains("Re")
                     ]
-                ].values.tolist()
+                ]
+                .to_numpy()
+                .tolist()
             )
-            prob.append(stage_df["p"].values.tolist())
+            prob.append(stage_df["p"].to_numpy().tolist())
 
         self.prob = prob
         self.p_d = p_d

--- a/sddip/sddip/parameters.py
+++ b/sddip/sddip/parameters.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+import natsort
 import numpy as np
 import pandas as pd
 
@@ -239,7 +240,9 @@ class Parameters:
         p_d = []
         re = []
 
-        sorted_columns = scenario_df.columns.sort_values()
+        sorted_columns = scenario_df.columns.sort_values(
+            key=lambda v: pd.Index(natsort.natsort_key(v), tupleize_cols=False)
+        )
         for t in range(self.n_stages):
             stage_df = pd.DataFrame(scenario_df[scenario_df["t"] == t + 1])
             p_d.append(

--- a/sddip/sddip/scenarios.py
+++ b/sddip/sddip/scenarios.py
@@ -45,12 +45,11 @@ class ScenarioGenerator:
             for max_value in max_value_targets
         ]
 
-        scenario_data = {"t": [1], "n": [1], "p": [1]}
-
         demand_bus_keys, no_demand_bus_keys = self.create_bus_keys(
             n_buses, demand_buses, "Pd"
         )
 
+        scenario_data: dict[str, list[float]] = {}
         # Set loads for buses without demand
         for b in no_demand_bus_keys:
             scenario_data[b] = [0] * self.n_total_realizations
@@ -63,18 +62,23 @@ class ScenarioGenerator:
                 )
             ]
 
+        probabilities: dict[str, list[float]] = {"t": [1], "n": [1], "p": [1]}
+
         # Set loads for stages >1
         for t in range(1, self.n_stages):
             for n in range(1, self.n_realizations_per_stage + 1):
-                scenario_data["t"].append(t + 1)
-                scenario_data["n"].append(n)
-                scenario_data["p"].append(1 / self.n_realizations_per_stage)
+                probabilities["t"].append(t + 1)
+                probabilities["n"].append(n)
+                probabilities["p"].append(1 / self.n_realizations_per_stage)
                 for b in range(len(demand_buses)):
                     scenario_data[demand_bus_keys[b]].append(
                         self.get_rdm_variation(
                             base_profiles[b][t], max_relative_variation
                         )
                     )
+
+        scenario_data = dict(sorted(scenario_data.items()))
+        scenario_data.update(probabilities)
 
         return pd.DataFrame(scenario_data)
 

--- a/sddip/sddip/scenarios.py
+++ b/sddip/sddip/scenarios.py
@@ -1,5 +1,6 @@
 import random as rdm
 
+import natsort
 import numpy as np
 import pandas as pd
 
@@ -77,7 +78,7 @@ class ScenarioGenerator:
                         )
                     )
 
-        scenario_data = dict(sorted(scenario_data.items()))
+        scenario_data = dict(natsort.natsorted(scenario_data.items()))
         scenario_data.update(probabilities)
 
         return pd.DataFrame(scenario_data)

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,15 @@ wheels = [
 ]
 
 [[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -334,6 +343,7 @@ source = { editable = "." }
 dependencies = [
     { name = "gurobipy" },
     { name = "matplotlib" },
+    { name = "natsort" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "scipy" },
@@ -350,6 +360,7 @@ dev = [
 requires-dist = [
     { name = "gurobipy", specifier = ">=13.0.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "natsort", specifier = ">=8.4.0" },
     { name = "numpy", specifier = ">=2.4.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "scipy", specifier = ">=1.16.3" },


### PR DESCRIPTION
Previously, demand scenarios were loaded under the assumption that the demand columns in `scenario_data.txt` were ordered by bus number. In practice, these columns were written out of order, which caused parameters to be initialized incorrectly at startup, assigning demand trajectories to the wrong buses.

This change resolves the issue by explicitly sorting demand-scenario columns naturally by bus number both when writing them to `scenario_data.txt` and when initializing parameters at the start of a simulation run.